### PR TITLE
Fix transitive dependency on actuators

### DIFF
--- a/contentgrid-spring-boot-platform/build.gradle
+++ b/contentgrid-spring-boot-platform/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     constraints {
         api project(':contentgrid-spring-boot-starter')
         api project(':contentgrid-spring-boot-starter-annotations')
+        api project(':contentgrid-spring-boot-actuators')
 
         ['rest', 'fs', 'jpa', 'mongo', 'rest', 's3', 'renditions', 'solr', 'elasticsearch'].each {
             api "com.github.paulcwarren:spring-content-${it}:${springContentVersion}"

--- a/contentgrid-spring-boot-starter/build.gradle
+++ b/contentgrid-spring-boot-starter/build.gradle
@@ -10,6 +10,7 @@ repositories {
 dependencies {
     api platform(project(':contentgrid-spring-boot-platform'))
     api "com.contentgrid.thunx:thunx-api-spring-boot-starter"
+    api "com.contentgrid.starter:contentgrid-spring-boot-actuators"
 
     api 'org.springframework.boot:spring-boot-starter-data-jpa'
     api 'org.springframework.boot:spring-boot-starter-actuator'


### PR DESCRIPTION
Before this, consumers needed to explicitly depend on contentgrid-spring-boot-actuators as well. Now they can just depend on the starter again.